### PR TITLE
add 'error' and 'errorString' fields

### DIFF
--- a/transmission.go
+++ b/transmission.go
@@ -42,6 +42,8 @@ type Torrent struct {
 	IsFinished    bool    `json:"isFinished"`
 	PercentDone   float64 `json:"percentDone"`
 	SeedRatioMode int     `json:"seedRatioMode"`
+	Error         int     `json:"error"`
+	ErrorString   string  `json:"errorString"`
 }
 
 //TorrentAdded data returning
@@ -86,8 +88,8 @@ func NewGetTorrentsCmd() (*Command, error) {
 	cmd.Method = "torrent-get"
 	cmd.Arguments.Fields = []string{"id", "name",
 		"status", "leftUntilDone", "eta", "uploadRatio",
-		"rateDownload", "rateUpload", "downloadDir",
-		"isFinished", "percentDone", "seedRatioMode"}
+		"rateDownload", "rateUpload", "downloadDir", "isFinished",
+		"percentDone", "seedRatioMode", "error", "errorString"}
 
 	return cmd, nil
 }


### PR DESCRIPTION
without these two fields it is impossible to recognize torrents with errors, and what's the error is all about, now it is possible to do the following

``` go
for _, torrent := range torrents {
    if torrent.Error != 0 {
        fmt.Println(torrent.Name, torrent.ErrorString)
    }
}
```
